### PR TITLE
Conditionally emitting 'newListener' event from 'prototype.on'

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -353,7 +353,9 @@
 
     // To avoid recursion in the case that type == "newListeners"! Before
     // adding it to the listeners, first emit "newListeners".
-    this.emit('newListener', type, listener);
+    if (this.newListener || this._events.newListener) {
+      this.emit('newListener', type, (typeof listener.listener === 'function') ? listener.listener : listener);
+    }
 
     if(this.wildcard) {
       growListenerTree.call(this, type, listener);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventemitter2",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "A Node.js event emitter implementation with namespaces, wildcards, TTL and browser support.",
   "keywords": ["event", "events", "emitter", "eventemitter"],
   "author": "hij1nx <hij1nx@nodejitsu.com> http://twitter.com/hij1nx",

--- a/test/simple/newListener.js
+++ b/test/simple/newListener.js
@@ -1,0 +1,50 @@
+
+var simpleEvents = require('nodeunit').testCase;
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if(typeof require !== 'undefined') {
+  EventEmitter2 = require(file).EventEmitter2;
+}
+else {
+  EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports = simpleEvents({
+
+  '1. newListener==true  && _events.newListener undefined: prototype.on should emit newListener': function (test) {
+
+    var emitter = new EventEmitter2({ verbose: true, newListener : true });
+
+    emitter.emit = function () { test.ok(true, 'Event "newListener" emited'); }   // hook .emit
+    emitter.on('test', function () {});   // should fire .emit newListener
+    
+    test.expect(1);
+    test.done();
+  }, 
+
+  '2. newListener==false && _events.newListener defined  : prototype.on should emit newListener': function (test) {
+
+    var emitter = new EventEmitter2({ verbose: true, newListener : false });
+
+    emitter.emit = function () { test.ok(true, 'Event "newListener" emited'); }
+    emitter.on('newListener', function() {} );  // define _events.newListener
+    emitter.on('test', function () {});   // should fire .emit newListener
+    
+    test.expect(1);
+    test.done();
+  },
+  
+  '3. newListener==false && _events.newListener undefined: prototype.on should not emit newListener': function (test) {
+
+    var emitter = new EventEmitter2({ verbose: true, newListener : false });
+
+    emitter.emit = function () { test.ok(false, 'Event "newListener" should not be emited'); }
+    emitter.on('test', function () {});   // should not fire .emit newListener
+    
+    test.expect();
+    test.done();
+  },
+  
+});
+


### PR DESCRIPTION
Allow 'newListener' to be emited from 'prototype.on' only if newListener option is true or listener for 'newListener' is defined.

Also added tests for the change in `test/simple/newListener.js`

All other tests running ok, `except wildcardEvents/k1.js` which I don't know what it is :-)

Hope I'm doing everything right, let me know if not. I'm still learning the ropes of github 