### PR TITLE
Issue#94

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -562,5 +562,4 @@
   } else {
     exports.EventEmitter2 = EventEmitter;
   }
-
-}(typeof process !== 'undefined' && typeof process.title !== 'undefined' && typeof exports !== 'undefined' ? exports : window);
+}(module && exports && module.exports === exports ? exports : window);

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -29,7 +29,7 @@
   }
 
   function EventEmitter(conf) {
-    this.__counter = 0;
+    this._counter = 0;
     this._events = {};
     this.newListener = false;
     configure.call(this, conf);
@@ -328,7 +328,7 @@
       for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
 
       var listeners = handler.slice().sort(function(a,b){
-	  a=a.__counter;b=b.__counter;
+	  a=a._counter;b=b._counter;
 	  return a === b ? 0 : ( a > b ? 1 : -1 );
       });
       for (var i = 0, l = listeners.length; i < l; i++) {
@@ -354,7 +354,7 @@
       throw new Error('on only accepts instances of Function');
     }
     this._events || init.call(this);
-    listener.__counter = this.__counter++;
+    listener._counter = this._counter++;
 
     // To avoid recursion in the case that type == "newListeners"! Before
     // adding it to the listeners, first emit "newListeners".

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -29,6 +29,7 @@
   }
 
   function EventEmitter(conf) {
+    this.__counter = 0;
     this._events = {};
     this.newListener = false;
     configure.call(this, conf);
@@ -326,7 +327,10 @@
       var args = new Array(l - 1);
       for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
 
-      var listeners = handler.slice();
+      var listeners = handler.slice().sort(function(a,b){
+	  a=a.__counter;b=b.__counter;
+	  return a === b ? 0 : ( a > b ? 1 : -1 );
+      });
       for (var i = 0, l = listeners.length; i < l; i++) {
         this.event = type;
         listeners[i].apply(this, args);
@@ -350,6 +354,7 @@
       throw new Error('on only accepts instances of Function');
     }
     this._events || init.call(this);
+    listener.__counter = this.__counter++;
 
     // To avoid recursion in the case that type == "newListeners"! Before
     // adding it to the listeners, first emit "newListeners".
@@ -558,4 +563,4 @@
     exports.EventEmitter2 = EventEmitter;
   }
 
-}(module && exports && module.exports === exports ? exports : window);
+}(typeof process !== 'undefined' && typeof process.title !== 'undefined' && typeof exports !== 'undefined' ? exports : window);


### PR DESCRIPTION
A simple counter is added to the EventEmitter object, wich will be raised with each addition of a listener. The current count will be attached to the event handling function. Before firing an array of callback functions, the array is sorted by the value of the counter, thus ensuring that the callback functions are fired in the same order they were attached, whether they contain wildcards or not. not sure how the sorting impacts performance though, I've never had the chance to look into testing.

#236b78f Merge pull request #98 from littlebitselectronics/component-support
EventEmitterHeatUp x 347,976 ops/sec ±1.88% (87 runs sampled)
EventEmitter x 377,166 ops/sec ±2.13% (84 runs sampled)
EventEmitter2 x 2,830,921 ops/sec ±3.23% (80 runs sampled)
EventEmitter2 (wild) x 1,009,743 ops/sec ±2.37% (88 runs sampled)

#6f03c81 sort events by a counter before firing them. adresses issue #94
EventEmitterHeatUp x 333,635 ops/sec ±2.15% (89 runs sampled)
EventEmitter x 376,798 ops/sec ±2.81% (89 runs sampled)
EventEmitter2 x 2,079,778 ops/sec ±2.76% (84 runs sampled)
EventEmitter2 (wild) x 822,199 ops/sec ±1.89% (89 runs sampled)

i see a slight to noticable performance decrease, but i can't trust my machine too much, as the ops/sec values vary up to 20% between consecutive runs. ( in the 10 runs before, for example, i had > 1.2 millions ops/sec in both cases of EventEmitter2 (wild) ).