### PR TITLE
Always export constructor

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -557,6 +557,8 @@
 
   };
 
+  EventEmitter.EventEmitter2 = EventEmitter;
+
   if (typeof define === 'function' && define.amd) {
      // AMD. Register as an anonymous module.
     define(function() {
@@ -564,7 +566,7 @@
     });
   } else if (typeof exports === 'object') {
     // CommonJS
-    exports.EventEmitter2 = EventEmitter;
+    module.exports = EventEmitter;
   }
   else {
     // Browser global.


### PR DESCRIPTION
Also adds a reference to the constructor back to itself to preserve backwards
compatibility.

Closes GH-121