### PR TITLE
Adds removeListener and removeListenerAny events

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ trace and exit the program.
 
 All EventEmitters emit the event `newListener` when new listeners are
 added. EventEmitters also emit the event `removeListener` when listeners are
-removed, and `removeListenerAll` when listeners added through `onAny` are
+removed, and `removeListenerAny` when listeners added through `onAny` are
 removed.
 
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ If there is no listener for it, then the default action is to print a stack
 trace and exit the program.
 
 All EventEmitters emit the event `newListener` when new listeners are
-added.
+added. EventEmitters also emit the event `removeListener` when listeners are
+removed, and `removeListenerAll` when listeners added through `onAny` are
+removed.
 
 
 **Namespaces** with **Wildcards**

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -459,11 +459,9 @@
 
         if(this.wildcard) {
           leaf._listeners.splice(position, 1);
-          this.emit("removeListener", type, listener);
         }
         else {
           this._events[type].splice(position, 1);
-          this.emit("removeListener", type, listener);
         }
 
         if (handlers.length === 0) {
@@ -474,6 +472,9 @@
             delete this._events[type];
           }
         }
+        
+        this.emit("removeListener", type, listener);
+        
         return this;
       }
       else if (handlers === listener ||
@@ -481,12 +482,12 @@
         (handlers._origin && handlers._origin === listener)) {
         if(this.wildcard) {
           delete leaf._listeners;
-          this.emit("removeListener", type, listener);
         }
         else {
           delete this._events[type];
-          this.emit("removeListener", type, listener);
         }
+        
+        this.emit("removeListener", type, listener);
       }
     }
 

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -459,9 +459,11 @@
 
         if(this.wildcard) {
           leaf._listeners.splice(position, 1);
+          this.emit("removeListener", type, listener);
         }
         else {
           this._events[type].splice(position, 1);
+          this.emit("removeListener", type, listener);
         }
 
         if (handlers.length === 0) {
@@ -479,9 +481,11 @@
         (handlers._origin && handlers._origin === listener)) {
         if(this.wildcard) {
           delete leaf._listeners;
+          this.emit("removeListener", type, listener);
         }
         else {
           delete this._events[type];
+          this.emit("removeListener", type, listener);
         }
       }
     }
@@ -496,10 +500,14 @@
       for(i = 0, l = fns.length; i < l; i++) {
         if(fn === fns[i]) {
           fns.splice(i, 1);
+          this.emit("removeListenerAny", fn);
           return this;
         }
       }
     } else {
+      fns = this._all;
+      for(i = 0, l = fns.length; i < l; i++)
+        this.emit("removeListenerAny", fns[i]);
       this._all = [];
     }
     return this;


### PR DESCRIPTION
Whenever a listener is removed, a `removeListener` event is emitted with the event type and a reference to the listener.

As well, when a listener is removed through `offAny`, a `removeListenerAny` event is emitted with a reference to the function that was removed.

Fixes #97 