### PR TITLE
GC on both .off and .removeAllListeners

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -10,7 +10,15 @@
   var isArray = Array.isArray ? Array.isArray : function _isArray(obj) {
     return Object.prototype.toString.call(obj) === "[object Array]";
   };
+
+  // stub for env vars
+  if (!process) {
+    process = { env: {} };
+  }
+
   var defaultMaxListeners = 10;
+  var gcKeyThreshold = parseInt(process.env.GC_KEY_THRESHOLD || 10000, 10);
+  var gcFrequency = parseInt(process.env.GC_FREQUENCY || 50000, 10);
 
   function init() {
     this._events = {};
@@ -37,6 +45,7 @@
 
   function EventEmitter(conf) {
     this._events = {};
+    this._gc = 0;
     this.newListener = false;
     configure.call(this, conf);
   }
@@ -212,6 +221,90 @@
       name = type.shift();
     }
     return true;
+  }
+
+  // remove all falsy values from the object
+  function makeShallowCopy(root, keys) {
+    var shallowCopy = {};
+
+    var key, obj;
+    for (var i in keys) {
+      key = keys[i];
+      obj = root[key];
+
+      if (obj) {
+        shallowCopy[key] = obj;
+      }
+    }
+
+    return shallowCopy;
+  }
+
+  // force garbage collection
+  function recursivelyGarbageCollect(root, isRecursive) {
+    // count how many gc calls we had, no need to recursively traverse the whole tree all the time
+    if (!isRecursive) {
+      if (++this._gc % gcFrequency !== 0) {
+        return;
+      }
+      this._gc = 0;
+      root = this.listenerTree;
+      console.time('gc-eventemitter2');
+    }
+
+    if (!root) {
+      return 0;
+    }
+
+    var keys = Object.keys(root),
+        keysLength = keys.length,
+        initialKeysLength = keysLength;
+
+    var key, obj, i;
+    var internalLength, prevInternalLength, internalKeys;
+    for (i in keys) {
+      key = keys[i];
+      obj = root[key];
+
+      if (obj instanceof Function) {
+        continue;
+      }
+
+      if (obj === null) {
+        keysLength--;
+        continue;
+      }
+
+      internalKeys = Object.keys(obj);
+      prevInternalLength = internalKeys.length;
+      if (prevInternalLength > 0) {
+        internalLength = recursivelyGarbageCollect.call(this, obj, true);
+        if (internalLength === 0) {
+          root[key] = null;
+          keysLength--;
+        } else if (prevInternalLength - internalLength > gcKeyThreshold) {
+          root[key] = makeShallowCopy(obj, internalKeys);
+        }
+      } else {
+        root[key] = null;
+        keysLength--;
+      }
+
+    }
+
+    // if we are in a recursive call,
+    if (isRecursive) {
+      return keysLength;
+    }
+
+    if (keysLength === 0) {
+      this.listenerTree = {};
+    } else if (initialKeysLength - keysLength > gcKeyThreshold) {
+      this.listenerTree = makeShallowCopy(root, keys);
+    }
+
+    console.timeEnd('gc-eventemitter2');
+    return keysLength;
   }
 
   // By default EventEmitters will print a warning if more than
@@ -466,10 +559,10 @@
 
         if (handlers.length === 0) {
           if(this.wildcard) {
-            delete leaf._listeners;
+            leaf._listeners = null;
           }
           else {
-            delete this._events[type];
+            this._events[type] = null;
           }
         }
         return this;
@@ -478,33 +571,15 @@
         (handlers.listener && handlers.listener === listener) ||
         (handlers._origin && handlers._origin === listener)) {
         if(this.wildcard) {
-          delete leaf._listeners;
+          leaf._listeners = null;
         }
         else {
-          delete this._events[type];
+          this._events[type] = null;
         }
       }
     }
 
-    function recursivelyGarbageCollect(root) {
-      if (root === undefined) {
-        return;
-      }
-      var keys = Object.keys(root);
-      for (var i in keys) {
-        var key = keys[i];
-        var obj = root[key];
-        if (obj instanceof Function)
-          continue;
-        if (Object.keys(obj).length > 0) {
-          recursivelyGarbageCollect(root[key]);
-        }
-        if (Object.keys(obj).length === 0) {
-          delete root[key];
-        }
-      }
-    }
-    recursivelyGarbageCollect(this.listenerTree);
+    recursivelyGarbageCollect.call(this);
 
     return this;
   };
@@ -546,6 +621,9 @@
       if (!this._events[type]) return this;
       this._events[type] = null;
     }
+
+    recursivelyGarbageCollect.call(this);
+
     return this;
   };
 

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -11,14 +11,9 @@
     return Object.prototype.toString.call(obj) === "[object Array]";
   };
 
-  // stub for env vars
-  if (!process) {
-    process = { env: {} };
-  }
-
   var defaultMaxListeners = 10;
-  var gcKeyThreshold = parseInt(process.env.GC_KEY_THRESHOLD || 10000, 10);
-  var gcFrequency = parseInt(process.env.GC_FREQUENCY || 50000, 10);
+  var gcKeyThreshold = parseInt(process && process.env && process.env.GC_KEY_THRESHOLD || 10000, 10);
+  var gcFrequency = parseInt(process && process.env && process.env.GC_FREQUENCY || 50000, 10);
 
   function init() {
     this._events = {};
@@ -249,7 +244,6 @@
       }
       this._gc = 0;
       root = this.listenerTree;
-      console.time('gc-eventemitter2');
     }
 
     if (!root) {
@@ -303,7 +297,6 @@
       this.listenerTree = makeShallowCopy(root, keys);
     }
 
-    console.timeEnd('gc-eventemitter2');
     return keysLength;
   }
 


### PR DESCRIPTION
Perform gc collection on both .off and .removeAllListeners,
extract `recursivelyGarbageCollect`, add `makeShallowCopy` for cleaning
lost of `null` properties, add gc invocation counters `this._gc`.

GC can be controlled via env vars `GC_KEY_THRESHOLD`, defaults to 10000.
Which means that a shallow copy of object will be created if it grows over
that amount of `null` properties.

`GC_FREQUENCY` controls how many calls to `recursivelyGarbageCollect` must be
made before we actually do the GC. Defaults to 50000

Addition to #65, #132 

Would love your comments. With default settings in my projects usual GC run takes from 150 to 250ms, which is, admittedly, not much granted how much it cleanses (ie, in an hour without that fix heap grows to 1GB).

What I haven't explored is using `.delete` instead of making shallow copies of an object and how it really affects performance here.
Ideas taken from this talk: https://www.youtube.com/watch?v=ip9LGtNsxZA