### PR TITLE
Fix removeListener when _events might not exist yet

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -547,7 +547,7 @@
       }
     }
     else {
-      if (!this._events[type]) return this;
+      if (!this._events || !this._events[type]) return this;
       this._events[type] = null;
     }
     return this;

--- a/test/simple/removeListener.js
+++ b/test/simple/removeListener.js
@@ -192,5 +192,18 @@ module.exports = simpleEvents({
 
     test.expect(4);
     test.done();
+  },
+
+  'removeListener8. when _events doesn\'t exist' : function (test) {
+
+    var emitter = new EventEmitter2;
+    var type = 'remove';
+
+    delete emitter._events;
+    emitter.removeAllListeners();
+    emitter.removeAllListeners(type);
+
+    test.expect(0);
+    test.done();
   }
 });


### PR DESCRIPTION
I added a test case for #116 and rebased it.