### PR TITLE
Fine tune emit performance to make it 1.25-1.7x faster

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -268,85 +268,95 @@
     var type = arguments[0];
 
     if (type === 'newListener' && !this.newListener) {
-      if (!this._events.newListener) { return false; }
-    }
-
-    // Loop through the *_all* functions and invoke them.
-    if (this._all) {
-      var l = arguments.length;
-      var args = new Array(l - 1);
-      for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
-      for (i = 0, l = this._all.length; i < l; i++) {
-        this.event = type;
-        this._all[i].apply(this, [type].concat(args));
-      }
-    }
-
-    // If there is no 'error' event listener then throw.
-    if (type === 'error') {
-
-      if (!this._all &&
-        !this._events.error &&
-        !(this.wildcard && this.listenerTree.error)) {
-
-        if (arguments[1] instanceof Error) {
-          throw arguments[1]; // Unhandled 'error' event
-        } else {
-          throw new Error("Uncaught, unspecified 'error' event.");
-        }
+      if (!this._events.newListener) {
         return false;
       }
     }
 
+    var al = arguments.length;
+    var args,l,i,j;
     var handler;
 
-    if(this.wildcard) {
+    if (this._all) {
+      if (al > 3) {
+        args = new Array(al);
+        for (j = 1; j < al; j++) args[j] = arguments[j];
+      }
+      for (i = 0, l = this._all.length; i < l; i++) {
+        this.event = type;
+        switch (al) {
+        case 1:
+          this._all[i].call(this, type);
+          break;
+        case 2:
+          this._all[i].call(this, type, arguments[1]);
+          break;
+        case 3:
+          this._all[i].call(this, type, arguments[1], arguments[2]);
+          break;
+        default:
+          this._all[i].apply(this, args);
+        }
+      }
+    }
+
+    if (this.wildcard) {
       handler = [];
       var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
-    }
-    else {
+    } else {
       handler = this._events[type];
     }
 
     if (typeof handler === 'function') {
       this.event = type;
-      if (arguments.length === 1) {
+      switch (al) {
+      case 1:
         handler.call(this);
+        break;
+      case 2:
+        handler.call(this, arguments[1]);
+        break;
+      case 3:
+        handler.call(this, arguments[1], arguments[2]);
+        break;
+      default:
+        args = new Array(al - 1);
+        for (j = 1; j < al; j++) args[j - 1] = arguments[j];
+        handler.apply(this, args);
       }
-      else if (arguments.length > 1)
-        switch (arguments.length) {
-          case 2:
-            handler.call(this, arguments[1]);
-            break;
-          case 3:
-            handler.call(this, arguments[1], arguments[2]);
-            break;
-          // slower
-          default:
-            var l = arguments.length;
-            var args = new Array(l - 1);
-            for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
-            handler.apply(this, args);
-        }
       return true;
-    }
-    else if (handler) {
-      var l = arguments.length;
-      var args = new Array(l - 1);
-      for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
-
-      var listeners = handler.slice();
-      for (var i = 0, l = listeners.length; i < l; i++) {
-        this.event = type;
-        listeners[i].apply(this, args);
+    } else if (handler && handler.length) {
+      if (al > 3) {
+        args = new Array(al - 1);
+        for (j = 1; j < al; j++) args[j - 1] = arguments[j];
       }
-      return (listeners.length > 0) || !!this._all;
-    }
-    else {
-      return !!this._all;
+      for (i = 0, l = handler.length; i < l; i++) {
+        this.event = type;
+        switch (al) {
+        case 1:
+          handler[i].call(this);
+          break;
+        case 2:
+          handler[i].call(this, arguments[1]);
+          break;
+        case 3:
+          handler[i].call(this, arguments[1], arguments[2]);
+          break;
+        default:
+          handler[i].apply(this, args);
+        }
+      }
+    } else if (!this._all && type === 'error') {
+      if (arguments[1] instanceof Error) {
+        throw arguments[1]; // Unhandled 'error' event
+      } else {
+        throw new Error("Uncaught, unspecified 'error' event.");
+      }
+      return false;
     }
 
+    return !!this._all;
   };
 
   EventEmitter.prototype.emitAsync = function() {
@@ -356,81 +366,92 @@
     var type = arguments[0];
 
     if (type === 'newListener' && !this.newListener) {
-      if (!this._events.newListener) { return Promise.resolve([false]); }
+        if (!this._events.newListener) { return Promise.resolve([false]); }
     }
 
     var promises= [];
 
-    // Loop through the *_all* functions and invoke them.
+    var al = arguments.length;
+    var args,l,i,j;
+    var handler;
+
     if (this._all) {
-      var l = arguments.length;
-      var args = new Array(l - 1);
-      for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+      if (al > 3) {
+        args = new Array(al);
+        for (j = 1; j < al; j++) args[j] = arguments[j];
+      }
       for (i = 0, l = this._all.length; i < l; i++) {
         this.event = type;
-        promises.push(this._all[i].apply(this, args));
-      }
-    }
-
-    // If there is no 'error' event listener then throw.
-    if (type === 'error') {
-
-      if (!this._all &&
-        !this._events.error &&
-        !(this.wildcard && this.listenerTree.error)) {
-
-        if (arguments[1] instanceof Error) {
-          return Promise.reject(arguments[1]); // Unhandled 'error' event
-        } else {
-          return Promise.reject("Uncaught, unspecified 'error' event.");
+        switch (al) {
+        case 1:
+          promises.push(this._all[i].call(this, type));
+          break;
+        case 2:
+          promises.push(this._all[i].call(this, type, arguments[1]));
+          break;
+        case 3:
+          promises.push(this._all[i].call(this, type, arguments[1], arguments[2]));
+          break;
+        default:
+          promises.push(this._all[i].apply(this, args));
         }
       }
     }
 
-    var handler;
-
-    if(this.wildcard) {
+    if (this.wildcard) {
       handler = [];
       var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
-    }
-    else {
+    } else {
       handler = this._events[type];
     }
 
     if (typeof handler === 'function') {
       this.event = type;
-      if (arguments.length === 1) {
+      switch (al) {
+      case 1:
         promises.push(handler.call(this));
+        break;
+      case 2:
+        promises.push(handler.call(this, arguments[1]));
+        break;
+      case 3:
+        promises.push(handler.call(this, arguments[1], arguments[2]));
+        break;
+      default:
+        args = new Array(al - 1);
+        for (j = 1; j < al; j++) args[j - 1] = arguments[j];
+        promises.push(handler.apply(this, args));
       }
-      else if (arguments.length > 1) {
-        switch (arguments.length) {
-          case 2:
-            promises.push(handler.call(this, arguments[1]));
-            break;
-          case 3:
-            promises.push(handler.call(this, arguments[1], arguments[2]));
-            break;
-          // slower
-          default:
-            var l = arguments.length;
-            var args = new Array(l - 1);
-            for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
-            promises.push(handler.apply(this, args));
+    } else if (handler && handler.length) {
+      if (al > 3) {
+        args = new Array(al - 1);
+        for (j = 1; j < al; j++) args[j - 1] = arguments[j];
+      }
+      for (i = 0, l = handler.length; i < l; i++) {
+        this.event = type;
+        switch (al) {
+        case 1:
+          promises.push(handler[i].call(this));
+          break;
+        case 2:
+          promises.push(handler[i].call(this, arguments[1]));
+          break;
+        case 3:
+          promises.push(handler[i].call(this, arguments[1], arguments[2]));
+          break;
+        default:
+          promises.push(handler[i].apply(this, args));
         }
       }
-    }
-    else if (handler) {
-      var l = arguments.length;
-      var args = new Array(l - 1);
-      for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
-
-      var listeners = handler.slice();
-      for (var i = 0, l = listeners.length; i < l; i++) {
-        this.event = type;
-        promises.push(listeners[i].apply(this, args));
+    } else if (!this._all && type === 'error') {
+      if (arguments[1] instanceof Error) {
+        return Promise.reject(arguments[1]); // Unhandled 'error' event
+      } else {
+        return Promise.reject("Uncaught, unspecified 'error' event.");
       }
     }
+
     return Promise.all(promises);
   };
 
@@ -562,9 +583,9 @@
             delete this._events[type];
           }
         }
-        
+
         this.emit("removeListener", type, listener);
-        
+
         return this;
       }
       else if (handlers === listener ||
@@ -576,7 +597,7 @@
         else {
           delete this._events[type];
         }
-        
+
         this.emit("removeListener", type, listener);
       }
     }

--- a/test/perf/steadyEmmiting.js
+++ b/test/perf/steadyEmmiting.js
@@ -1,0 +1,175 @@
+
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+
+// basic emitter
+var EventEmitter = require('events').EventEmitter;
+var emitter = new EventEmitter();
+
+var EventEmitter2 = require('../../lib/eventemitter2').EventEmitter2;
+
+
+// Emitter2 variations
+var emitter2 = new EventEmitter2();
+var emitter3 = new EventEmitter2();
+var emitter4 = new EventEmitter2({wildcard:true});
+var emitter5 = new EventEmitter2({wildcard:true});
+var emitter6 = new EventEmitter2();
+var emitter7 = new EventEmitter2({wildcard:true});
+
+var t;
+
+emitter.on('test1', function () { t=1; });
+emitter.on('test1', function () { t=1; });
+emitter.on('test2.foo', function () { t=1; });
+
+emitter2.on('test1', function () { t=1; });
+emitter2.on('test2', function () { t=1; });
+emitter2.on('test2.foo', function () { t=1; });
+
+emitter3.on('test1', function () { t=1; });
+emitter3.on('test2', function () { t=1; });
+emitter3.on('test2.foo', function () { t=1; });
+emitter3.onAny( function () { t=1; });
+
+emitter4.on('test1', function () { t=1; });
+emitter4.on('test2', function () { t=1; });
+emitter4.on('test2.foo', function () { t=1; });
+
+emitter5.on('test1', function () { t=1; });
+emitter5.on('test2', function () { t=1; });
+emitter5.on('test2.foo', function () { t=1; });
+emitter5.onAny( function () { t=1; });
+
+emitter6.on('test1', function () { t=1; });
+emitter6.on('test1', function () { t=1; });
+emitter6.on('test1', function () { t=1; });
+emitter6.on('test1', function () { t=1; });
+emitter6.on('test2', function () { t=1; });
+emitter6.on('test4', function () { t=1; });
+emitter6.on('test5', function () { t=1; });
+emitter6.on('test6', function () { t=1; });
+emitter6.on('test7', function () { t=1; });
+emitter6.onAny( function () { t=1; });
+emitter6.onAny( function () { t=1; });
+emitter6.onAny( function () { t=1; });
+emitter6.onAny( function () { t=1; });
+
+emitter7.on('test1.one', function () { t=1; });
+emitter7.on('*.one', function () { t=1; });
+emitter7.on('test1.one', function () { t=1; });
+emitter7.on('test1.two', function () { t=1; });
+emitter7.on('*.two', function () { t=1; });
+emitter7.on('*.*', function () { t=1; });
+emitter7.on('test1.*', function () { t=1; });
+emitter7.on('**', function () { t=1; });
+emitter7.on('*.*', function () { t=1; });
+emitter7.onAny( function () { t=1; });
+emitter7.onAny( function () { t=1; });
+emitter7.onAny( function () { t=1; });
+emitter7.onAny( function () { t=1; });
+
+suite
+  .add('Test HeatUp', function() {
+    emitter.emit('test1');
+  })
+  .add('All at once', function () {
+    for (var emmiter in [emitter2,emitter3,emitter4,emitter5,emitter6]) {
+      emitter.emit('test1');
+      emitter.emit('test1',1);
+      emitter.emit('test1',1,2);
+      emitter.emit('test1',1,2,3);
+    }
+    emitter7.emit('test1.one');
+    emitter7.emit('test1.one',1);
+    emitter7.emit('test1.one',1,2);
+    emitter7.emit('test1.one',1,2,3);
+  })
+  .add('EventEmitter', function() {
+    emitter.emit('test1');
+  })
+  .add('EventEmitter 1', function() {
+    emitter.emit('test1',1);
+  })
+  .add('EventEmitter 1 2', function() {
+	  emitter.emit('test1',1,2);
+  })
+  .add('EventEmitter 1 2 3', function() {
+    emitter.emit('test1',1,2,3);
+  })
+  .add('EventEmitter2', function() {
+    emitter2.emit('test1');
+  })
+  .add('EventEmitter2 1', function() {
+    emitter2.emit('test1',1);
+  })
+  .add('EventEmitter2 1 2', function() {
+    emitter2.emit('test1',1,2);
+  })
+  .add('EventEmitter2 1 2 3', function() {
+    emitter2.emit('test1',1,2,3);
+  })
+ .add('EventEmitter2 +any', function() {
+    emitter3.emit('test1',1);
+  })
+  .add('EventEmitter2 +any 1', function() {
+    emitter3.emit('test1',1);
+  })
+  .add('EventEmitter2 +any 1 2', function() {
+    emitter3.emit('test1',1,2);
+  })
+  .add('EventEmitter2 +any 1 2 3', function() {
+    emitter3.emit('test1',1,2,3);
+  })
+  .add('EventEmitter2 wild', function() {
+    emitter4.emit('test1');
+  })
+  .add('EventEmitter2 wild 1', function() {
+    emitter4.emit('test1',1);
+  })
+  .add('EventEmitter2 wild 1 2', function() {
+    emitter4.emit('test1',1,2);
+  })
+  .add('EventEmitter2 wild 1 2 3', function() {
+    emitter4.emit('test1',1,2,3);
+  })
+  .add('EventEmitter2 wild +any', function() {
+    emitter5.emit('test1');
+  })
+  .add('EventEmitter2 wild +any 1', function() {
+    emitter5.emit('test1',1);
+  })
+  .add('EventEmitter2 wild +any 1 2', function() {
+    emitter5.emit('test1',1,2);
+  })
+  .add('EventEmitter2 wild +any 1 2 3', function() {
+    emitter5.emit('test1',1,2,3);
+  })
+  .add('EventEmitter2 complex', function() {
+    emitter6.emit('test1');
+  })
+  .add('EventEmitter2 complex 1', function() {
+    emitter6.emit('test1',1);
+  })
+  .add('EventEmitter2 complex 1 2', function() {
+    emitter6.emit('test1',1,2);
+  })
+  .add('EventEmitter2 complex 1 2 3', function() {
+    emitter6.emit('test1',1,2,3);
+  })
+  .add('EventEmitter2 wild complex', function() {
+    emitter7.emit('test1.one');
+  })
+  .add('EventEmitter2 wild complex 1', function() {
+    emitter7.emit('test1.one',1);
+  })
+  .add('EventEmitter2 wild complex 1 2', function() {
+    emitter7.emit('test1.one',1,2);
+  })
+  .add('EventEmitter2 wild complex 1 2 3', function() {
+    emitter7.emit('test1.one',1,2,3);
+  })
+  .on('cycle', function(event, bench) {
+    console.log(String(event.target));
+  })
+  .run(true);


### PR DESCRIPTION
Hi there. We actively use EventEmitter2 as part of tinyhook distributed event emitter. We have really big projects on it and start facing issues with performance. On this project we have dedicated process that hosts only one instance of tinyhook (extension of eventemitter2) and its sole purpose is dispatching (emitting of events). Load is really huge, close to dozens of thousands of messages per second and CPU load is also huge.
Based on our investigation we discovered that some part can be optimized in EventEmitter2 code and this merge request has optimized version of emit and emitAsync methods. There is no functional changes introduced, behaviour is exactly the same. 
To proof the improvement we create bench /test/perf/steadyEmitting.js. It shows 25 to 70% improvement. 
Optimized: ```All at once x 140,049 ops/sec ±0.87% (89 runs sampled)```
Current: ```All at once x 85,365 ops/sec ±0.65% (90 runs sampled)```