### PR TITLE
Add tests for wildcard emit return value

### DIFF
--- a/test/simple/emit.js
+++ b/test/simple/emit.js
@@ -138,5 +138,21 @@ module.exports = simpleEvents({
     test.done();
   },
 
+  '7. Check return values of wildcardEmitter.emit.': function (test) {
+    var emitter = new EventEmitter2({ verbose: true, wildcard: true });
+    function functionA() { test.ok(true, 'The event was raised'); }
+
+    emitter.on('test7', functionA);
+    emitter.on('wildcard.*', functionA);
+
+    test.ok(emitter.emit('test7'), 'emit should return true after calling a listener');
+    test.ok(emitter.emit('wildcard.7'), 'emit should return true after calling a wildcard listener');
+    test.ok(!emitter.emit('other7'), 'emit should return false when no listener was called');
+    test.ok(!emitter.emit('other.7'), 'emit should return false when no wildcard listener was called');
+
+    test.expect(6);
+    test.done();
+  },
+
 });
 


### PR DESCRIPTION
The return value of the `eventEmitter.emit` method of an EventEmitter2 instance that supports wildcard events isn't `true` anymore since EventEmitter2@1.0.1.

Something in this pr must have gone wrong: https://github.com/asyncly/EventEmitter2/pull/163 
I've added some tests for that functionality.

Here's the regression bug that appears since v1.0.1:
```js
var emitter = new EventEmitter2({ verbose: true, wildcard: true });
emitter.on('foo', function () {})
console.log(emitter.emit('foo', 'bar'))
// -> false
```