### PR TITLE
Fixed typings file to meet use strict

### DIFF
--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -11,12 +11,12 @@ declare module eventemitter2 {
          * @default '.'
          * @description the delimiter used to segment namespaces.
          */
-        delimiter?: string, 
+        delimiter?: string,
         /**
          * @default true
          * @description set this to `true` if you want to emit the newListener events.
          */
-        newListener?: boolean, 
+        newListener?: boolean,
         /**
          * @default 10
          * @description the maximum amount of listeners that can be assigned to an event.
@@ -34,19 +34,19 @@ declare module eventemitter2 {
         new(options?: eventemitter2.ConstructorOptions): eventemitter2.emitter
     }
     interface emitter {
-        emit(event: string| string[],...values: any[]);
+        emit(event: string| string[],...values: any[]): boolean;
         emitAsync(event: string): Promise<any[]>;
-        addListener(event: string, listener: Listener);
-        on(event: string, listener: Listener);
-        once(event: string, listener: Listener);
-        many(event: string, timesToListen: number, listener: Listener);
-        many(events: string[], listener: Listener);
-        onAny(listener: EventAndListener);
-        offAny(listener: Listener);
-        removeListener(event: string, listener: Listener);
-        off(event: string, listener: Listener);
-        removeAllListeners(evetns?: string[]);
-        setMaxListeners(n: number);
+        addListener(event: string, listener: Listener): emitter;
+        on(event: string, listener: Listener): emitter;
+        once(event: string, listener: Listener): emitter;
+        many(event: string, timesToListen: number, listener: Listener): emitter;
+        many(events: string[], listener: Listener): emitter;
+        onAny(listener: EventAndListener): emitter;
+        offAny(listener: Listener): emitter;
+        removeListener(event: string, listener: Listener): emitter;
+        off(event: string, listener: Listener): emitter;
+        removeAllListeners(evetns?: string[]): emitter;
+        setMaxListeners(n: number): void;
         listeners(event: string): ()=>{}[] // TODO: not in documentation by Willian
         listenersAny():           ()=>{}[] // TODO: not in documentation by Willian
     }
@@ -54,7 +54,6 @@ declare module eventemitter2 {
         then(onFulfilled:(response: ReturnType) => any, onRejected:(response: any) => any): Promise<any>;
         catch(onRejected:(response: any) => any): Promise<any>;
     }
-} 
-
+}
 
 export {eventemitter2 as EventEmitter2 };


### PR DESCRIPTION
Hi,

the embeded typings file seems to fail with "use strict" option:

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(37,9): error TS7010: 'emit', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(39,9): error TS7010: 'addListener', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(40,9): error TS7010: 'on', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(41,9): error TS7010: 'once', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(42,9): error TS7010: 'many', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(43,9): error TS7010: 'many', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(44,9): error TS7010: 'onAny', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(45,9): error TS7010: 'offAny', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(46,9): error TS7010: 'removeListener', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(47,9): error TS7010: 'off', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(48,9): error TS7010: 'removeAllListeners', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in /node_modules/eventemitter2/eventemitter2.d.ts
(49,9): error TS7010: 'setMaxListeners', which lacks return-type annotation, implicitly has an 'any' return type.

I fixed it, feel free to merge :)