### PR TITLE
make typing compatible with angular2 AOT

### DIFF
--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -1,65 +1,53 @@
-declare let eventemitter2: eventemitter2.Static
-
-declare module eventemitter2 {
-    type eventNS = string[];
-    interface ConstructorOptions {
-        /**
-         * @default false
-         * @description set this to `true` to use wildcards.
-         */
-        wildcard?: boolean,
-        /**
-         * @default '.'
-         * @description the delimiter used to segment namespaces.
-         */
-        delimiter?: string,
-        /**
-         * @default true
-         * @description set this to `true` if you want to emit the newListener events.
-         */
-        newListener?: boolean,
-        /**
-         * @default 10
-         * @description the maximum amount of listeners that can be assigned to an event.
-         */
-        maxListeners?: number
-        /**
-         * @default false
-         * @description show event name in memory leak message when more than maximum amount of listeners is assigned, default false
-         */
-        verboseMemoryLeak?: boolean;
-    }
-    interface Listener{
-        (...values: any[]) : void;
-    }
-    interface EventAndListener{
-        (event: string,...values: any[]) : void;
-    }
-
-    interface Static {
-        new(options?: eventemitter2.ConstructorOptions): eventemitter2.emitter
-    }
-    interface emitter {
-        emit(event: string| string[],...values: any[]): boolean;
-        emitAsync(event: string| string[],...values: any[]): Promise<any[]>;
-        addListener(event: string, listener: Listener): emitter;
-        on(event: string, listener: Listener): emitter;
-        once(event: string, listener: Listener): emitter;
-        many(event: string, timesToListen: number, listener: Listener): emitter;
-        many(events: string[], listener: Listener): emitter;
-        onAny(listener: EventAndListener): emitter;
-        offAny(listener: Listener): emitter;
-        removeListener(event: string, listener: Listener): emitter;
-        off(event: string, listener: Listener): emitter;
-        removeAllListeners(event?: string | eventNS): emitter;
-        setMaxListeners(n: number): void;
-        listeners(event: string): ()=>{}[] // TODO: not in documentation by Willian
-        listenersAny():           ()=>{}[] // TODO: not in documentation by Willian
-    }
-    interface Promise<ReturnType> {
-        then(onFulfilled:(response: ReturnType) => any, onRejected:(response: any) => any): Promise<any>;
-        catch(onRejected:(response: any) => any): Promise<any>;
-    }
+export type eventNS = string[];
+export interface ConstructorOptions {
+    /**
+     * @default false
+     * @description set this to `true` to use wildcards.
+     */
+    wildcard?: boolean,
+    /**
+     * @default '.'
+     * @description the delimiter used to segment namespaces.
+     */
+    delimiter?: string,
+    /**
+     * @default true
+     * @description set this to `true` if you want to emit the newListener events.
+     */
+    newListener?: boolean,
+    /**
+     * @default 10
+     * @description the maximum amount of listeners that can be assigned to an event.
+     */
+    maxListeners?: number
+    /**
+     * @default false
+     * @description show event name in memory leak message when more than maximum amount of listeners is assigned, default false
+     */
+    verboseMemoryLeak?: boolean;
+}
+export interface Listener {
+    (...values: any[]): void;
+}
+export interface EventAndListener {
+    (event: string, ...values: any[]): void;
 }
 
-export {eventemitter2 as EventEmitter2 };
+export declare class EventEmitter2 {
+    constructor(options?: ConstructorOptions)
+    emit(event: string | string[], ...values: any[]): boolean;
+    emitAsync(event: string | string[], ...values: any[]): Promise<any[]>;
+    addListener(event: string, listener: Listener): this;
+    on(event: string, listener: Listener): this;
+    once(event: string, listener: Listener): this;
+    many(event: string, timesToListen: number, listener: Listener): this;
+    many(events: string[], listener: Listener): this;
+    onAny(listener: EventAndListener): this;
+    offAny(listener: Listener): this;
+    removeListener(event: string, listener: Listener): this;
+    off(event: string, listener: Listener): this;
+    removeAllListeners(event?: string | eventNS): this;
+    setMaxListeners(n: number): void;
+    listeners(event: string): () => {}[] // TODO: not in documentation by Willian
+    listenersAny(): () => {}[] // TODO: not in documentation by Willian
+}


### PR DESCRIPTION
it resolves error in AOT: ``Error encountered resolving symbol values statically``

the breaking change is instead of using ``EventEmitter2.emitter`` to define event instance type, just simply use ``EventEmitter2``