### PR TITLE
Implement node 6 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,15 @@ Only this method doesn't work [IE](http://caniuse.com/#search=promise).
       console.log(results); // [3,2,1,0,undefined]
     });
 ```
+
+### emitter.eventNames()
+
+Returns an array listing the events for which the emitter has registered listeners. The values in the array will be strings.
+
+```javascript
+    emitter.on('foo', () => {});
+    emitter.on('bar', () => {});
+
+    console.log(emitter.eventNames());
+    // Prints: [ 'foo', 'bar' ]
+```

--- a/README.md
+++ b/README.md
@@ -146,12 +146,33 @@ Adds a listener to the end of the listeners array for the specified event.
     });
 ```
 
+### emitter.prependListener(event, listener)
+
+Adds a listener to the beginning of the listeners array for the specified event.
+
+```javascript
+    server.prependListener('data', function(value1, value2, value3, ...) {
+      console.log('The event was raised!');
+    });
+```
+
+
 ### emitter.onAny(listener)
 
 Adds a listener that will be fired when any event is emitted. The event name is passed as the first argument to the callback.
 
 ```javascript
     server.onAny(function(event, value) {
+      console.log('All events trigger this.');
+    });
+```
+
+### emitter.prependAny(listener)
+
+Adds a listener that will be fired when any event is emitted. The event name is passed as the first argument to the callback. The listener is added to the beginning of the listeners array
+
+```javascript
+    server.prependAny(function(event, value) {
       console.log('All events trigger this.');
     });
 ```
@@ -177,6 +198,18 @@ only the first time the event is fired, after which it is removed.
     });
 ```
 
+#### emitter.prependOnceListener(event, listener)
+
+Adds a **one time** listener for the event. The listener is invoked 
+only the first time the event is fired, after which it is removed.
+The listener is added to the beginning of the listeners array
+
+```javascript
+    server.prependOnceListener('get', function (value) {
+      console.log('Ah, we have our first value!');
+    });
+```
+
 ### emitter.many(event, timesToListen, listener)
 
 Adds a listener that will execute **n times** for the event before being
@@ -188,6 +221,20 @@ fired, after which it is removed.
       console.log('This event will be listened to exactly four times.');
     });
 ```
+
+### emitter.prependMany(event, timesToListen, listener)
+
+Adds a listener that will execute **n times** for the event before being
+removed. The listener is invoked only the first **n times** the event is 
+fired, after which it is removed.
+The listener is added to the beginning of the listeners array.
+
+```javascript
+    server.many('get', 4, function (value) {
+      console.log('This event will be listened to exactly four times.');
+    });
+```
+
 
 
 ### emitter.removeListener(event, listener)

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -39,14 +39,19 @@ export declare class EventEmitter2 {
     emitAsync(event: string | string[], ...values: any[]): Promise<any[]>;
     addListener(event: string, listener: Listener): this;
     on(event: string | string[], listener: Listener): this;
+    prependListener(event: string | string[], listener: Listener): this;
     once(event: string | string[], listener: Listener): this;
+    prependOnceListener(event: string | string[], listener: Listener): this;
     many(event: string | string[], timesToListen: number, listener: Listener): this;
+    prependMany(event: string | string[], timesToListen: number, listener: Listener): this;
     onAny(listener: EventAndListener): this;
+    prependAny(listener: EventAndListener): this;
     offAny(listener: Listener): this;
     removeListener(event: string | string[], listener: Listener): this;
     off(event: string, listener: Listener): this;
     removeAllListeners(event?: string | eventNS): this;
     setMaxListeners(n: number): void;
+    eventNames(): string[];
     listeners(event: string | string[]): () => {}[] // TODO: not in documentation by Willian
     listenersAny(): () => {}[] // TODO: not in documentation by Willian
 }

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -245,12 +245,29 @@
 
   EventEmitter.prototype.event = '';
 
+
   EventEmitter.prototype.once = function(event, fn) {
-    this.many(event, 1, fn);
+    return this._once(event, fn, false);
+  };
+
+  EventEmitter.prototype.prependOnceListener = function(event, fn) {
+    return this._once(event, fn, true);
+  };
+
+  EventEmitter.prototype._once = function(event, fn, prepend) {
+    this._many(event, 1, fn, prepend);
     return this;
   };
 
   EventEmitter.prototype.many = function(event, ttl, fn) {
+    return this._many(event, ttl, fn, false);
+  }
+
+  EventEmitter.prototype.prependMany = function(event, ttl, fn) {
+    return this._many(event, ttl, fn, true);
+  }
+
+  EventEmitter.prototype._many = function(event, ttl, fn, prepend) {
     var self = this;
 
     if (typeof fn !== 'function') {
@@ -266,7 +283,7 @@
 
     listener._origin = fn;
 
-    this.on(event, listener);
+    this._on(event, listener, prepend);
 
     return self;
   };
@@ -475,8 +492,45 @@
   };
 
   EventEmitter.prototype.on = function(type, listener) {
+    return this._on(type, listener, false);
+  };
+
+  EventEmitter.prototype.prependListener = function(type, listener) {
+    return this._on(type, listener, true);
+  };
+
+  EventEmitter.prototype.onAny = function(fn) {
+    return this._addAny(fn, false);
+  };
+
+  EventEmitter.prototype.prependAny = function(fn) {
+    return this._addAny(fn, true);
+  };
+
+  EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+
+  EventEmitter.prototype._addAny = function(fn, prepend){
+    if (typeof fn !== 'function') {
+      throw new Error('onAny only accepts instances of Function');
+    }
+
+    if (!this._all) {
+      this._all = [];
+    }
+
+    // Add the function to the event listener collection.
+    if(prepend){
+      this._all.unshift(fn);
+    }else{
+      this._all.push(fn);
+    }
+    
+    return this;
+  }
+
+  EventEmitter.prototype._on = function(type, listener, prepend) {
     if (typeof type === 'function') {
-      this.onAny(type);
+      this._addAny(type, listener);
       return this;
     }
 
@@ -504,9 +558,13 @@
         this._events[type] = [this._events[type]];
       }
 
-      // If we've already got an array, just append.
-      this._events[type].push(listener);
-
+      // If we've already got an array, just add
+      if(prepend){
+        this._events[type].unshift(listener);
+      }else{
+        this._events[type].push(listener);
+      }
+      
       // Check for listener leak
       if (
         !this._events[type].warned &&
@@ -519,23 +577,7 @@
     }
 
     return this;
-  };
-
-  EventEmitter.prototype.onAny = function(fn) {
-    if (typeof fn !== 'function') {
-      throw new Error('onAny only accepts instances of Function');
-    }
-
-    if (!this._all) {
-      this._all = [];
-    }
-
-    // Add the function to the event listener collection.
-    this._all.push(fn);
-    return this;
-  };
-
-  EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+  }
 
   EventEmitter.prototype.off = function(type, listener) {
     if (typeof listener !== 'function') {

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -500,16 +500,16 @@
   };
 
   EventEmitter.prototype.onAny = function(fn) {
-    return this._addAny(fn, false);
+    return this._onAny(fn, false);
   };
 
   EventEmitter.prototype.prependAny = function(fn) {
-    return this._addAny(fn, true);
+    return this._onAny(fn, true);
   };
 
   EventEmitter.prototype.addListener = EventEmitter.prototype.on;
 
-  EventEmitter.prototype._addAny = function(fn, prepend){
+  EventEmitter.prototype._onAny = function(fn, prepend){
     if (typeof fn !== 'function') {
       throw new Error('onAny only accepts instances of Function');
     }
@@ -530,7 +530,7 @@
 
   EventEmitter.prototype._on = function(type, listener, prepend) {
     if (typeof type === 'function') {
-      this._addAny(type, listener);
+      this._onAny(type, listener);
       return this;
     }
 

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -24,7 +24,8 @@
       this._conf = conf;
 
       conf.delimiter && (this.delimiter = conf.delimiter);
-      this._events.maxListeners = conf.maxListeners !== undefined ? conf.maxListeners : defaultMaxListeners;
+      this._maxListeners = conf.maxListeners !== undefined ? conf.maxListeners : defaultMaxListeners;
+     
       conf.wildcard && (this.wildcard = conf.wildcard);
       conf.newListener && (this.newListener = conf.newListener);
       conf.verboseMemoryLeak && (this.verboseMemoryLeak = conf.verboseMemoryLeak);
@@ -33,7 +34,7 @@
         this.listenerTree = {};
       }
     } else {
-      this._events.maxListeners = defaultMaxListeners;
+      this._maxListeners = defaultMaxListeners;
     }
   }
 
@@ -211,8 +212,8 @@
 
           if (
             !tree._listeners.warned &&
-            this._events.maxListeners > 0 &&
-            tree._listeners.length > this._events.maxListeners
+            this._maxListeners > 0 &&
+            tree._listeners.length > this._maxListeners
           ) {
             tree._listeners.warned = true;
             logPossibleMemoryLeak.call(this, tree._listeners.length, name);
@@ -236,8 +237,7 @@
 
   EventEmitter.prototype.setMaxListeners = function(n) {
     if (n !== undefined) {
-      this._events || init.call(this);
-      this._events.maxListeners = n;
+      this._maxListeners = n;
       if (!this._conf) this._conf = {};
       this._conf.maxListeners = n;
     }
@@ -568,8 +568,8 @@
       // Check for listener leak
       if (
         !this._events[type].warned &&
-        this._events.maxListeners > 0 &&
-        this._events[type].length > this._events.maxListeners
+        this._maxListeners > 0 &&
+        this._events[type].length > this._maxListeners
       ) {
         this._events[type].warned = true;
         logPossibleMemoryLeak.call(this, this._events[type].length, type);
@@ -733,6 +733,10 @@
     }
     return this._events[type];
   };
+
+  EventEmitter.prototype.eventNames = function(){
+    return Object.keys(this._events);
+  }
 
   EventEmitter.prototype.listenerCount = function(type) {
     return this.listeners(type).length;

--- a/test/simple/eventNames.js
+++ b/test/simple/eventNames.js
@@ -1,0 +1,28 @@
+var simpleEvents = require('nodeunit').testCase;
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if(typeof require !== 'undefined') {
+  EventEmitter2 = require(file).EventEmitter2;
+}
+else {
+  EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports = simpleEvents({
+
+  '1. Test event names function.': function (test) {
+
+    var emitter = new EventEmitter2({ verbose: true });
+
+    emitter.on('foo', () => {});
+    emitter.on('bar', () => {});
+
+    var eventNames = emitter.eventNames();
+    eventNames.sort();
+    test.equal(eventNames.length, 2);
+    test.equal(eventNames[0],'bar');
+    test.equal(eventNames[1],'foo');
+    test.done();
+  }
+});

--- a/test/simple/prepend.js
+++ b/test/simple/prepend.js
@@ -1,0 +1,58 @@
+var simpleEvents = require('nodeunit').testCase;
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if(typeof require !== 'undefined') {
+  EventEmitter2 = require(file).EventEmitter2;
+}
+else {
+  EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports = simpleEvents({
+
+  '1. Add a listener before another one on a single event.': function (test) {
+
+    var emitter = new EventEmitter2({ verbose: true });
+
+    var raised = false;
+    var second = function () {
+      test.ok(raised, 'The event was raised in incorrect order');
+      test.done();
+    };
+    emitter.on('test1', second);
+
+    var first = function () {
+      test.ok(!raised, 'The event was raised in incorrect order');
+      raised = true;
+    };
+    emitter.prependListener('test1', first);
+
+    test.equal(emitter.listeners('test1').length, 2);
+    test.equal(emitter.listeners('test1')[0], first);
+    test.equal(emitter.listeners('test1')[1], second);
+    emitter.emit('test1');
+
+
+  },
+  '2. prepend listener for any event' : function (test) {
+
+    var emitter = new EventEmitter2({ verbose: true });
+
+    var raised = false;
+    var second = function () {
+      test.ok(raised, 'The event was raised in incorrect order');
+      test.done();
+    };
+    emitter.onAny(second);
+
+    var first = function () {
+      test.ok(!raised, 'The event was raised in incorrect order');
+      raised = true;
+    };
+    emitter.prependAny(first);
+
+    emitter.emit('random');
+  
+  }
+});

--- a/test/simple/reconfigure.js
+++ b/test/simple/reconfigure.js
@@ -24,7 +24,7 @@ module.exports = simpleEvents({
 
     emitter.removeAllListeners();
 
-    test.equal(emitter._events.maxListeners, config.maxListeners, 'should be ' + config.maxListeners);
+    test.equal(emitter._maxListeners, config.maxListeners, 'should be ' + config.maxListeners);
 
     test.equal(emitter._conf.maxListeners, config.maxListeners, 'should be ' + config.maxListeners);
     test.equal(emitter._conf.delimiter, config.delimiter, 'should be ' + config.delimiter);
@@ -44,7 +44,7 @@ module.exports = simpleEvents({
 
     emitter.removeAllListeners();
 
-    test.equal(emitter._events.maxListeners, amount, 'should be ' + amount);
+    test.equal(emitter._maxListeners, amount, 'should be ' + amount);
 
     test.equal(emitter._conf.maxListeners, amount, 'should be ' + amount);
 


### PR DESCRIPTION
Implements the node 6 functions:
- `prependListener`
- `prependOnceListener`
- `eventNames`

It also adds similar `prepend` methods that are specific to this library:
- `prependMany`
- `prependAny`

There are tests, documentation and typescript defs.

**note**
- I moved the `maxListeners` property of the `_events` object. This seemed like bad design to mix this with event names (e.g. when someone actually wants to have a `maxListeners` event).
- The `eventNames` function is not fully compatible with the node implementation. That's because the node implementation uses `Reflect.keys` instead of `Object.keys`. The former has not so much browser support and since you guys don't have any transpiler infrastructure, I chose to use `Object.keys` instead for the time being.

Fixes: https://github.com/asyncly/EventEmitter2/issues/208