### PR TITLE
Correct listeners and listenersAny typings

### DIFF
--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -52,6 +52,6 @@ export declare class EventEmitter2 {
     removeAllListeners(event?: string | eventNS): this;
     setMaxListeners(n: number): void;
     eventNames(): string[];
-    listeners(event: string | string[]): () => {}[] // TODO: not in documentation by Willian
-    listenersAny(): () => {}[] // TODO: not in documentation by Willian
+    listeners(event: string | string[]): Listener[] // TODO: not in documentation by Willian
+    listenersAny(): Listener[] // TODO: not in documentation by Willian
 }


### PR DESCRIPTION
The typings for `listeners` and `listenersAny` are incorrect. At the very least, they require parentheses to enclose the return type's function signature. However, this PR goes further and uses the declared `Listener` signature.

Closes #217.