### PR TITLE
Fix breaking changes from #207

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -27,8 +27,8 @@
       this._maxListeners = conf.maxListeners !== undefined ? conf.maxListeners : defaultMaxListeners;
 
       conf.wildcard && (this.wildcard = conf.wildcard);
-      conf.newListener && (this.newListener = conf.newListener);
-      conf.removeListener && (this.removeListener = conf.removeListener);
+      conf.newListener && (this._newListener = conf.newListener);
+      conf.removeListener && (this._removeListener = conf.removeListener);
       conf.verboseMemoryLeak && (this.verboseMemoryLeak = conf.verboseMemoryLeak);
 
       if (this.wildcard) {
@@ -65,8 +65,8 @@
 
   function EventEmitter(conf) {
     this._events = {};
-    this.newListener = false;
-    this.removeListener = false;
+    this._newListener = false;
+    this._removeListener = false;
     this.verboseMemoryLeak = false;
     configure.call(this, conf);
   }
@@ -303,7 +303,7 @@
 
     var type = arguments[0];
 
-    if (type === 'newListener' && !this.newListener) {
+    if (type === 'newListener' && !this._newListener) {
       if (!this._events.newListener) {
         return false;
       }
@@ -409,7 +409,7 @@
 
     var type = arguments[0];
 
-    if (type === 'newListener' && !this.newListener) {
+    if (type === 'newListener' && !this._newListener) {
         if (!this._events.newListener) { return Promise.resolve([false]); }
     }
 
@@ -550,7 +550,7 @@
 
     // To avoid recursion in the case that type == "newListeners"! Before
     // adding it to the listeners, first emit "newListeners".
-    if (this.newListener)
+    if (this._newListener)
        this.emit('newListener', type, listener);
 
     if (this.wildcard) {
@@ -642,7 +642,7 @@
             delete this._events[type];
           }
         }
-        if (this.removeListener)
+        if (this._removeListener)
           this.emit("removeListener", type, listener);
 
         return this;
@@ -656,7 +656,7 @@
         else {
           delete this._events[type];
         }
-        if (this.removeListener)
+        if (this._removeListener)
           this.emit("removeListener", type, listener);
       }
     }
@@ -691,14 +691,14 @@
       for(i = 0, l = fns.length; i < l; i++) {
         if(fn === fns[i]) {
           fns.splice(i, 1);
-          if (this.removeListener)
+          if (this._removeListener)
             this.emit("removeListenerAny", fn);
           return this;
         }
       }
     } else {
       fns = this._all;
-      if (this.removeListener) {
+      if (this._removeListener) {
         for(i = 0, l = fns.length; i < l; i++)
           this.emit("removeListenerAny", fns[i]);
       }


### PR DESCRIPTION
#207 accidentally broke the removeListener function.

- Renamed the `this.removeListener` boolean to be `this._removeListener`. Same for `this.newListener`