### PR TITLE
Fixes #229 by calling map() instead of pluck()

### DIFF
--- a/test/perf/benchmark.js
+++ b/test/perf/benchmark.js
@@ -47,7 +47,7 @@ suite
     console.log(String(event.target));
   })
   .on('complete', function() {
-    console.log('\nFastest is ' + this.filter('fastest').pluck('name'));
+    console.log('\nFastest is ' + this.filter('fastest').map('name'));
   })
 
   .run(true);


### PR DESCRIPTION
Fixes #229 

Output:

```
$ node ./test/perf/benchmark.js 
EventEmitterHeatUp x 3,519,153 ops/sec ±1.12% (88 runs sampled)
EventEmitter x 3,555,339 ops/sec ±1.32% (93 runs sampled)
EventEmitter2 x 10,933,903 ops/sec ±1.21% (90 runs sampled)
EventEmitter2 (wild) x 7,525,248 ops/sec ±1.79% (89 runs sampled)

Fastest is EventEmitter2
```